### PR TITLE
Updating imgui-rs to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 categories = ["gui", "rendering"]
 
 [dependencies]
-imgui = "0.8.2"
+imgui = "0.9.0"
 windows = { version = "0.43.0", features = [
     "Win32_Foundation",
     "Win32_Graphics_Direct3D",
@@ -21,11 +21,11 @@ windows = { version = "0.43.0", features = [
 ] }
 
 [dev-dependencies]
-imgui = "0.8.2"
-imgui-winit-support = "0.8.2"
+imgui = "0.9.0"
+imgui-winit-support = "0.9.0"
 raw-window-handle = "0.3.0"
 windows = { version = "0.43.0", features = ["Win32_Graphics_Gdi"] }
-winit = "0.25.0"
+winit = "0.27.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -109,9 +109,9 @@ fn main() {
             }
 
             let ui = imgui.frame();
-            imgui::Window::new("Hello world")
+            ui.window("Hello world")
                 .size([300.0, 100.0], imgui::Condition::FirstUseEver)
-                .build(&ui, || {
+                .build(|| {
                     ui.text("Hello world!");
                     ui.text("This...is...imgui-rs!");
                     ui.separator();
@@ -119,8 +119,8 @@ fn main() {
                     ui.text(&format!("Mouse Position: ({:.1},{:.1})", mouse_pos[0], mouse_pos[1]));
                 });
             ui.show_demo_window(&mut true);
-            platform.prepare_render(&ui, &window);
-            renderer.render(ui.render()).unwrap();
+            platform.prepare_render(ui, &window);
+            renderer.render(imgui.render()).unwrap();
             unsafe {
                 device.EndScene().unwrap();
                 device.Present(ptr::null_mut(), ptr::null_mut(), None, ptr::null_mut()).unwrap();

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -108,7 +108,7 @@ fn main() {
                 device.BeginScene().unwrap();
             }
 
-            let ui = imgui.frame();
+            let ui = imgui.new_frame();
             ui.window("Hello world")
                 .size([300.0, 100.0], imgui::Condition::FirstUseEver)
                 .build(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ impl Renderer {
     // FIXME, imgui hands us an rgba texture while we make dx9 think it receives an
     // argb texture
     unsafe fn create_font_texture(
-        mut fonts: imgui::FontAtlasRefMut<'_>,
+        mut fonts: &mut imgui::FontAtlas,
         device: &IDirect3DDevice9,
     ) -> Result<IDirect3DTexture9> {
         let texture = fonts.build_rgba32_texture();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,12 +217,12 @@ impl Renderer {
         device.SetRenderState(D3DRS_SHADEMODE, D3DSHADE_GOURAUD.0 as u32)?;
         device.SetRenderState(D3DRS_ZWRITEENABLE, FALSE)?;
         device.SetRenderState(D3DRS_ALPHATESTENABLE, FALSE)?;
-        device.SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE.0 as u32)?;
+        device.SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE.0)?;
         device.SetRenderState(D3DRS_ZENABLE, FALSE)?;
         device.SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE)?;
-        device.SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD.0 as u32)?;
-        device.SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA.0 as u32)?;
-        device.SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA.0 as u32)?;
+        device.SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD.0)?;
+        device.SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA.0)?;
+        device.SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA.0)?;
         device.SetRenderState(D3DRS_SEPARATEALPHABLENDENABLE, TRUE)?;
         device.SetRenderState(D3DRS_SRCBLENDALPHA, D3DBLEND_ONE.0)?;
         device.SetRenderState(D3DRS_DESTBLENDALPHA, D3DBLEND_INVSRCALPHA.0)?;


### PR DESCRIPTION
 Updated the dependencies to match imgui-rs 0.9.0 release and made the proper changes on `imgui::Window` according to the new version.
Also updated `.frame()` to `.new_frame()` and removed some unnecessary casts.