### PR TITLE
Update dependencies: windows 0.44.0 -> 0.48.0; imgui 0.10.0 -> 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-dx9-renderer"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Lukas Wirth <lukastw97@gmail.com>"]
 edition = "2021"
 description = "DirectX 9 renderer for the imgui crate"
@@ -11,8 +11,8 @@ readme = "README.md"
 categories = ["gui", "rendering"]
 
 [dependencies]
-imgui = "0.10.0"
-windows = { version = "0.44.0", features = [
+imgui = "0.11.0"
+windows = { version = "0.48.0", features = [
     "Win32_Foundation",
     "Foundation_Numerics",
     "Win32_Graphics_Direct3D",
@@ -22,11 +22,11 @@ windows = { version = "0.44.0", features = [
 ] }
 
 [dev-dependencies]
-imgui = "0.10.0"
-imgui-winit-support = "0.10.0"
-raw-window-handle = "0.5.0"
-windows = { version = "0.44.0", features = ["Win32_Graphics_Gdi"] }
-winit = "0.27.5"
+imgui = "0.11.0"
+imgui-winit-support = "0.11.0"
+raw-window-handle = "0.5.2"
+windows = { version = "0.48.0", features = ["Win32_Graphics_Gdi"] }
+winit = "0.27.5" # Would update to 0.28.3; but imgui-winit-support still uses 0.27.5
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use windows::Win32::Graphics::Dxgi::DXGI_ERROR_INVALID_CALL;
 use windows::Win32::System::SystemServices::{
     D3DFVF_DIFFUSE, D3DFVF_TEX1, D3DFVF_XYZ, D3DTA_DIFFUSE, D3DTA_TEXTURE,
 };
+use windows::core::ComInterface;
 
 const FONT_TEX_ID: usize = !0;
 const D3DFVF_CUSTOMVERTEX: u32 = D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1;
@@ -86,8 +87,8 @@ impl Renderer {
     ///
     /// [`IDirect3DDevice9`]: https://docs.rs/winapi/0.3/x86_64-pc-windows-msvc/winapi/shared/d3d9/struct.IDirect3DDevice9.html
     pub unsafe fn new(ctx: &mut Context, device: IDirect3DDevice9) -> Result<Self> {
-        let font_tex =
-            IDirect3DBaseTexture9::from(Self::create_font_texture(ctx.fonts(), &device)?);
+		let t = Self::create_font_texture(ctx.fonts(), &device)?;
+        let font_tex: IDirect3DBaseTexture9 = t.cast()?;
 
         ctx.io_mut().backend_flags |= BackendFlags::RENDERER_HAS_VTX_OFFSET;
         ctx.set_renderer_name(String::from(concat!(
@@ -392,7 +393,7 @@ impl Renderer {
     // FIXME, imgui hands us an rgba texture while we make dx9 think it receives an
     // argb texture
     unsafe fn create_font_texture(
-        mut fonts: &mut imgui::FontAtlas,
+        fonts: &mut imgui::FontAtlas,
         device: &IDirect3DDevice9,
     ) -> Result<IDirect3DTexture9> {
         let texture = fonts.build_rgba32_texture();


### PR DESCRIPTION
This PR updates windows and imgui dependencies.
It also fixes #12 

I didn't test it, it compiles and is able to run the winit example:
```shell
cargo +nightly run --example winit
```